### PR TITLE
logger追加

### DIFF
--- a/SnapSearch.xcodeproj/project.pbxproj
+++ b/SnapSearch.xcodeproj/project.pbxproj
@@ -279,6 +279,8 @@
 /* Begin XCBuildConfiguration section */
 		D9DC3F7F2E90C293004A40E2 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = D9DC3F622E90C28F004A40E2 /* SnapSearch */;
+			baseConfigurationReferenceRelativePath = Config/Debug.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -342,6 +344,8 @@
 		};
 		D9DC3F802E90C293004A40E2 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = D9DC3F622E90C28F004A40E2 /* SnapSearch */;
+			baseConfigurationReferenceRelativePath = Config/Release.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -518,6 +522,125 @@
 			};
 			name = Release;
 		};
+		D9DC3FD32E9106EF004A40E2 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = D9DC3F622E90C28F004A40E2 /* SnapSearch */;
+			baseConfigurationReferenceRelativePath = Config/Beta.xcconfig;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Beta;
+		};
+		D9DC3FD42E9106EF004A40E2 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fujimori.SnapSearch;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Beta;
+		};
+		D9DC3FD52E9106EF004A40E2 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fujimori.SnapSearchTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SnapSearch.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SnapSearch";
+			};
+			name = Beta;
+		};
+		D9DC3FD62E9106EF004A40E2 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fujimori.SnapSearchUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SnapSearch;
+			};
+			name = Beta;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -526,6 +649,7 @@
 			buildConfigurations = (
 				D9DC3F7F2E90C293004A40E2 /* Debug */,
 				D9DC3F802E90C293004A40E2 /* Release */,
+				D9DC3FD32E9106EF004A40E2 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -535,6 +659,7 @@
 			buildConfigurations = (
 				D9DC3F822E90C293004A40E2 /* Debug */,
 				D9DC3F832E90C293004A40E2 /* Release */,
+				D9DC3FD42E9106EF004A40E2 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -544,6 +669,7 @@
 			buildConfigurations = (
 				D9DC3F852E90C293004A40E2 /* Debug */,
 				D9DC3F862E90C293004A40E2 /* Release */,
+				D9DC3FD52E9106EF004A40E2 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -553,6 +679,7 @@
 			buildConfigurations = (
 				D9DC3F882E90C293004A40E2 /* Debug */,
 				D9DC3F892E90C293004A40E2 /* Release */,
+				D9DC3FD62E9106EF004A40E2 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SnapSearch/Config/Beta.xcconfig
+++ b/SnapSearch/Config/Beta.xcconfig
@@ -1,0 +1,9 @@
+//
+//  Beta.xcconfig
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/04
+//  
+
+// ログレベルを指定
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR

--- a/SnapSearch/Config/Debug.xcconfig
+++ b/SnapSearch/Config/Debug.xcconfig
@@ -1,0 +1,9 @@
+//
+//  Debug.xcconfig
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/04
+//  
+
+// ログレベルを指定
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR

--- a/SnapSearch/Config/Release.xcconfig
+++ b/SnapSearch/Config/Release.xcconfig
@@ -1,0 +1,9 @@
+//
+//  Release.xcconfig
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/04
+//  
+
+// ログレベルを指定
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited)

--- a/SnapSearch/Core/Logger/AppLog.swift
+++ b/SnapSearch/Core/Logger/AppLog.swift
@@ -1,0 +1,106 @@
+//
+//  AppLog.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/04
+//  
+
+import OSLog
+
+let logger = AppLog.self
+
+enum LogCategory: String {
+    case app
+    case view
+    case network
+    case system
+}
+
+enum AppLog {
+    // OSが発信元を識別できるようsubsystemにBundleIDを使う
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "app.unknown"
+
+    private static func makeLogger(for category: LogCategory) -> Logger {
+        Logger(subsystem: subsystem, category: category.rawValue)
+    }
+
+    #if LOG_DEBUG
+    static func debug(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        makeLogger(for: category).debug("🟩 [\(file):\(line)] \(function) - \(message())")
+    }
+    #else
+    @inline(__always) static func debug(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {}
+    #endif
+
+    #if LOG_INFO
+    static func info(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        makeLogger(for: category).info("🟦 [\(file):\(line)] \(function) - \(message())")
+    }
+    #else
+    @inline(__always) static func info(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {}
+    #endif
+
+    #if LOG_WARN
+    static func warn(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        makeLogger(for: category).warning("🟨 [\(file):\(line)] \(function) - \(message())")
+    }
+    #else
+    @inline(__always) static func warn(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {}
+    #endif
+
+    #if LOG_ERROR
+    static func error(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        makeLogger(for: category).error("🟥 [\(file):\(line)] \(function) - \(message())")
+    }
+    #else
+    @inline(__always) static func error(
+        _ category: LogCategory = .app,
+        _ message: @autoclosure @escaping () -> String,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {}
+    #endif
+}


### PR DESCRIPTION
## 概要
アプリ全体で利用できる統一的なログ仕組みを追加。

## 変更内容
- Apple純正の`OSLog` / `Logger`を利用した`AppLog`を実装
- `.xcconfig` を構成（Debug / Beta / Release）ごとに分離し、`SWIFT_ACTIVE_COMPILATION_CONDITIONS`でフラグを定義

## 動作確認
<!-- 動作確認した内容をチェックリストで記述 -->
- [x] ビルドができること
- [x] デバッグ実行でログ出力されること

## スクリーンショット
<!-- UI変更がある場合は貼ってください -->

## その他
<!-- レビューしてほしい観点やTODOなど -->
