### PR TITLE
DependencyValues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,11 +42,23 @@ jobs:
       # 6. ビルド ＆ テスト
       - name: Build and test
         run: |
-          xcodebuild test \
+          DERIVED=$HOME/Library/Developer/Xcode/DerivedData/SnapSearch-DD
+          xcodebuild build-for-testing \
+            -project SnapSearch.xcodeproj \
+            -scheme SnapSearch \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' \
+            -derivedDataPath "$DERIVED" \
+            -enableCodeCoverage NO \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            -only-testing:SnapSearchTests \
+          | xcpretty
+
+          xcodebuild test-without-building \
             -project SnapSearch.xcodeproj \
             -scheme SnapSearch \
             -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' \
-            -enableCodeCoverage YES \
-            -skipPackagePluginValidation \
-            -skipMacroValidation \
+            -derivedDataPath "$DERIVED" \
+            -only-testing:SnapSearchTests \
           | xcpretty

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: iOS CI
 
 on:
-  push:
-    branches: ["*"]
   pull_request:
     branches: ["*"]
 
@@ -42,6 +40,7 @@ jobs:
       # 6. ビルド ＆ テスト
       - name: Build and test
         run: |
+          set -o pipefail
           DERIVED=$HOME/Library/Developer/Xcode/DerivedData/SnapSearch-DD
 
           xcodebuild build-for-testing \
@@ -53,7 +52,8 @@ jobs:
             -enableCodeCoverage NO \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            -only-testing:SnapSearchTests
+            -only-testing:SnapSearchTests \
+          | xcpretty
 
           xcodebuild test-without-building \
             -project SnapSearch.xcodeproj \
@@ -62,5 +62,4 @@ jobs:
             -derivedDataPath "$DERIVED" \
             -only-testing:SnapSearchTests \
             -enableCodeCoverage NO \
-            -resultBundlePath TestResults \
-            | tee xcodebuild.log
+          | xcpretty

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Build and test
         run: |
           DERIVED=$HOME/Library/Developer/Xcode/DerivedData/SnapSearch-DD
+
           xcodebuild build-for-testing \
             -project SnapSearch.xcodeproj \
             -scheme SnapSearch \
@@ -52,8 +53,7 @@ jobs:
             -enableCodeCoverage NO \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            -only-testing:SnapSearchTests \
-          | xcpretty
+            -only-testing:SnapSearchTests
 
           xcodebuild test-without-building \
             -project SnapSearch.xcodeproj \
@@ -61,4 +61,6 @@ jobs:
             -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' \
             -derivedDataPath "$DERIVED" \
             -only-testing:SnapSearchTests \
-          | xcpretty
+            -enableCodeCoverage NO \
+            -resultBundlePath TestResults \
+            | tee xcodebuild.log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,7 @@ jobs:
             -enableCodeCoverage NO \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            -only-testing:SnapSearchTests \
-          | xcpretty
+            -only-testing:SnapSearchTests
 
           xcodebuild test-without-building \
             -project SnapSearch.xcodeproj \
@@ -61,5 +60,4 @@ jobs:
             -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' \
             -derivedDataPath "$DERIVED" \
             -only-testing:SnapSearchTests \
-            -enableCodeCoverage NO \
-          | xcpretty
+            -enableCodeCoverage NO

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,4 @@
+disabled_rules:
+
+trailing_whitespace:
+  ignores_empty_lines: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,7 @@
 disabled_rules:
 
+# 空行時はtrailing_whitespaceの警告が出ないよう調整している
+# （Enter押下し改行したときにデフォルトで空白が入るため）
 trailing_whitespace:
   ignores_empty_lines: true
+  

--- a/SnapSearch/Core/DependencyInjection/DependencyValues.swift
+++ b/SnapSearch/Core/DependencyInjection/DependencyValues.swift
@@ -1,0 +1,76 @@
+//
+//  DependencyValues.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/06
+//  
+
+protocol DependencyKey {
+    
+    associatedtype Value: Sendable
+    static var liveValue: Value { get }
+}
+
+struct DependencyValues: Sendable {
+    
+    @TaskLocal fileprivate static var current = Self()
+    private var storage: [ObjectIdentifier: Sendable] = [:]
+    
+    // swiftlint:disable:next unneeded_synthesized_initializer
+    private init() {}
+    
+    subscript<K>(key: K.Type) -> K.Value where K: DependencyKey {
+        
+        get {
+            
+            guard let base = storage[ObjectIdentifier(key)],
+                  let dependency = base as? K.Value else {
+                
+                return key.liveValue
+            }
+            return dependency
+        }
+        
+        set {
+            
+            storage[ObjectIdentifier(key)] = newValue
+        }
+    }
+}
+
+extension DependencyValues {
+    
+    static func withDependency<R>(
+        _ setDependency: (inout DependencyValues) -> Void,
+        operation: () -> R) -> R {
+        
+        var currentDependencyValue = DependencyValues.current
+        setDependency(&currentDependencyValue)
+        
+        return DependencyValues.$current.withValue(currentDependencyValue) { operation() }
+    }
+    
+    static func withDependency<R>(
+        _ setDependency: (inout DependencyValues) -> Void,
+        operation: () async -> R
+    ) async -> R {
+        
+        var currentDependencyValue = DependencyValues.current
+        setDependency(&currentDependencyValue)
+        
+        return await DependencyValues.$current.withValue(currentDependencyValue) { await operation() }
+    }
+}
+
+@propertyWrapper
+struct Dependency<Value> {
+    
+    private let keyPath: KeyPath<DependencyValues, Value> & Sendable
+
+    init(_ keyPath: KeyPath<DependencyValues, Value> & Sendable) {
+        
+        self.keyPath = keyPath
+    }
+
+    var wrappedValue: Value { DependencyValues.current[keyPath: keyPath] }
+}

--- a/SnapSearchTests/DependencyValuesTests.swift
+++ b/SnapSearchTests/DependencyValuesTests.swift
@@ -1,0 +1,156 @@
+//
+//  DependencyValuesTests.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/06
+//  
+
+@testable import SnapSearch
+import Testing
+
+// MARK: - テストデータ
+
+enum FeatureFlagKey: DependencyKey {
+    static let liveValue: Bool = false
+}
+
+struct UserConfig: Sendable, Equatable {
+    var name: String
+    var level: Int
+}
+
+enum UserConfigKey: DependencyKey {
+    static let liveValue: UserConfig = .init(name: "live", level: 0)
+}
+
+extension DependencyValues {
+    var featureEnabled: Bool {
+        get { self[FeatureFlagKey.self] }
+        set { self[FeatureFlagKey.self] = newValue }
+    }
+    var userConfig: UserConfig {
+        get {self[UserConfigKey.self] }
+        set { self[UserConfigKey.self] = newValue}
+    }
+}
+
+struct FeatureConsumer {
+    @Dependency(\.featureEnabled) var enabled: Bool
+    func isOn() -> Bool { enabled }
+}
+
+struct ConfigConsumer {
+    @Dependency(\.userConfig) var config: UserConfig
+    func current() -> UserConfig { config }
+}
+
+// MARK: - テスト
+
+@Suite
+struct DependencyValuesTests {
+    
+    @Test
+    func FeatureConsumerが_依存未設定の時_liveValueを返す() {
+        // given: 依存未設定
+        let consumer = FeatureConsumer()
+        // when: 参照
+        let v = consumer.isOn()
+        // then: liveValue(false)
+        #expect(v == false)
+    }
+
+    @Test
+    func FeatureConsumerが_同期スコープ内の時_上書き値trueを返しスコープ外はfalseを返す() {
+        // given: 外側はfalse
+        #expect(FeatureConsumer().isOn() == false)
+
+        // when: 同期スコープでtrueに上書き
+        let inside = DependencyValues.withDependency {
+            $0.featureEnabled = true
+        } operation: {
+            FeatureConsumer().isOn()
+        }
+
+        // then: 内=true 外=false
+        #expect(inside == true)
+        #expect(FeatureConsumer().isOn() == false)
+    }
+
+    @Test
+    func 依存スコープが_ネストされた時_内側の値が優先される() {
+        // given+when: 外= true → 内= false → 外に戻る
+        let tuple = DependencyValues.withDependency {
+            $0.featureEnabled = true
+        } operation: {
+            let outer = FeatureConsumer().isOn()
+            let inner = DependencyValues.withDependency({ $0[FeatureFlagKey.self] = false }) {
+                FeatureConsumer().isOn()
+            }
+            let outerAgain = FeatureConsumer().isOn()
+            return (outer, inner, outerAgain)
+        }
+
+        // then
+        #expect(tuple.0 == true)
+        #expect(tuple.1 == false)
+        #expect(tuple.2 == true)
+        #expect(FeatureConsumer().isOn() == false)
+    }
+
+    @Test
+    func 子Taskが_非同期スコープ内の時_上書き値を参照する() async {
+        // given: 外側はfalse
+        #expect(FeatureConsumer().isOn() == false)
+
+        // when: 非同期スコープでtrueに上書きし子Taskで参照
+        let (direct, child) = await DependencyValues.withDependency {
+            $0.featureEnabled = true
+        } operation: {
+            let d = FeatureConsumer().isOn()
+            let c = await Task { FeatureConsumer().isOn() }.value
+            return (d, c)
+        }
+
+        // then: スコープ内と子Taskの両方でtrue
+        #expect(direct == true)
+        #expect(child == true)
+        #expect(FeatureConsumer().isOn() == false)
+    }
+
+    @Test
+    func 別キーが_上書きされた時_他のキーに影響しない() {
+        // given: 両キーlive
+        #expect(FeatureConsumer().isOn() == false)
+        #expect(ConfigConsumer().current() == .init(name: "live", level: 0))
+
+        // when: UserConfigのみ上書き
+        let (cfgIn, flagIn) = DependencyValues.withDependency {
+            $0.userConfig = .init(name: "custom", level: 2)
+        } operation: {
+            (ConfigConsumer().current(), FeatureConsumer().isOn())
+        }
+
+        // then: UserConfigだけ変化/FeatureFlagは不変
+        #expect(cfgIn == .init(name: "custom", level: 2))
+        #expect(flagIn == false)
+
+        // スコープ外は元に戻る
+        #expect(ConfigConsumer().current() == .init(name: "live", level: 0))
+        #expect(FeatureConsumer().isOn() == false)
+    }
+
+    @Test
+    func 同一タスクが_awaitをまたぐ時_上書き値を維持する() async {
+        // given+when: 非同期スコープでtrueに上書きしawait境界を挟む
+        let kept = await DependencyValues.withDependency {
+            $0.featureEnabled = true
+        } operation: {
+            _ = await Task { () }.value  // 微小await
+            return FeatureConsumer().isOn()
+        }
+
+        // then: 同一タスク内ではtrueを維持、外ではfalse
+        #expect(kept == true)
+        #expect(FeatureConsumer().isOn() == false)
+    }
+}


### PR DESCRIPTION
## 概要
DIと依存元をテスト容易にするため、`DependencyValues`を導入する。
以下ライブラリの最低限の機能を自前実装している。

> https://github.com/pointfreeco/swift-dependencies

## 変更内容
- `DependencyValues`を実装
- `.swiftlint.yml`に空行時に`trailing_whitespace`の警告を出さないルールを追加
- CIが遅かったので合わせて`ci.yaml`を修正

## 動作確認
<!-- 動作確認した内容をチェックリストで記述 -->
- [x] ビルドができること

## スクリーンショット
<!-- UI変更がある場合は貼ってください -->

## その他
<!-- レビューしてほしい観点やTODOなど -->
