### PR TITLE
APIリクエスト周りのUnitTest実装

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,8 @@
 name: iOS CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ "*" ]
 
 env:
   PROJECT: SnapSearch.xcodeproj

--- a/SnapSearch/Network/APIConfiguration.swift
+++ b/SnapSearch/Network/APIConfiguration.swift
@@ -17,7 +17,7 @@ struct APIConfiguration {
 
 // MARK: - APIError
 
-enum APIError: LocalizedError, Sendable {
+enum APIError: LocalizedError, Equatable {
     case invalidURL
     case noData
     case decodingError(String)

--- a/SnapSearchTests/APIEndpointTests.swift
+++ b/SnapSearchTests/APIEndpointTests.swift
@@ -1,5 +1,5 @@
 //
-//  APIEndpointURLTests.swift
+//  APIEndpointTests.swift
 //  SnapSearch
 //  
 //  Created by Daiki Fujimori on 2025/10/12

--- a/SnapSearchTests/APIEndpointURLTests.swift
+++ b/SnapSearchTests/APIEndpointURLTests.swift
@@ -1,0 +1,105 @@
+//
+//  APIEndpointURLTests.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/12
+//  
+
+@testable import SnapSearch
+import Testing
+
+// MARK: - APIEndpointURLTests
+
+@Suite
+struct APIEndpointURLTests {
+    
+    @Test
+    func searchエンドポイントが_queryとpageとperPageを渡した時_全てのパラメータを含むURLが生成される() {
+        // Given: searchエンドポイントにquery="nature"、page=2、perPage=20を設定
+        let endpoint = APIEndpoint.search(query: "nature", page: 2, perPage: 20)
+        let baseURL = "https://api.pexels.com/v1"
+        
+        // When: baseURLを使ってURLを生成した時
+        let url = endpoint.url(baseURL: baseURL)
+        
+        // Then: URLが生成され、/searchパスと3つのクエリパラメータが全て含まれる
+        #expect(url != nil)
+        #expect(url?.absoluteString.contains("/search") ?? false)
+        #expect(url?.absoluteString.contains("query=nature") ?? false)
+        #expect(url?.absoluteString.contains("page=2") ?? false)
+        #expect(url?.absoluteString.contains("per_page=20") ?? false)
+    }
+    
+    @Test
+    func curatedエンドポイントが_pageとperPageを渡した時_2つのパラメータを含むURLが生成される() {
+        // Given: curatedエンドポイントにpage=3、perPage=15を設定
+        let endpoint = APIEndpoint.curated(page: 3, perPage: 15)
+        let baseURL = "https://api.pexels.com/v1"
+        
+        // When: baseURLを使ってURLを生成した時
+        let url = endpoint.url(baseURL: baseURL)
+        
+        // Then: URLが生成され、/curatedパスとpageとper_pageパラメータが含まれ、queryパラメータは含まれない
+        #expect(url != nil)
+        #expect(url?.absoluteString.contains("/curated") ?? false)
+        #expect(url?.absoluteString.contains("page=3") ?? false)
+        #expect(url?.absoluteString.contains("per_page=15") ?? false)
+        #expect(!(url?.absoluteString.contains("query=") ?? false))
+    }
+    
+    @Test
+    func photoエンドポイントが_IDを渡した時_IDを含むパスが生成される() {
+        // Given: photoエンドポイントにID=12345を設定
+        let photoID = 12345
+        let endpoint = APIEndpoint.photo(id: photoID)
+        let baseURL = "https://api.pexels.com/v1"
+        
+        // When: baseURLを使ってURLを生成した時
+        let url = endpoint.url(baseURL: baseURL)
+        
+        // Then: /photos/12345というパスのURLが生成される
+        #expect(url?.absoluteString == "https://api.pexels.com/v1/photos/12345")
+    }
+}
+
+// MARK: - APIEndpointPathTests
+
+@Suite
+struct APIEndpointPathTests {
+    
+    @Test
+    func searchエンドポイントが_pathを取得する時_searchが返される() {
+        // Given: query="test"のsearchエンドポイントを作成
+        let endpoint = APIEndpoint.search(query: "test", page: 1, perPage: 10)
+        
+        // When: pathプロパティを取得した時
+        let path = endpoint.path
+        
+        // Then: "/search"という文字列が返される
+        #expect(path == "/search")
+    }
+    
+    @Test
+    func curatedエンドポイントが_pathを取得する時_curatedが返される() {
+        // Given: curatedエンドポイントを作成
+        let endpoint = APIEndpoint.curated(page: 1, perPage: 10)
+        
+        // When: pathプロパティを取得した時
+        let path = endpoint.path
+        
+        // Then: "/curated"という文字列が返される
+        #expect(path == "/curated")
+    }
+    
+    @Test
+    func photoエンドポイントが_ID99を渡した時_photos99が返される() {
+        // Given: ID=99のphotoエンドポイントを作成
+        let endpoint = APIEndpoint.photo(id: 99)
+        
+        // When: pathプロパティを取得した時
+        let path = endpoint.path
+        
+        // Then: "/photos/99"という文字列が返される
+        #expect(path == "/photos/99")
+    }
+}

--- a/SnapSearchTests/DependencyValuesTests.swift
+++ b/SnapSearchTests/DependencyValuesTests.swift
@@ -10,147 +10,381 @@ import Testing
 
 // MARK: - テストデータ
 
-enum FeatureFlagKey: DependencyKey {
+private struct TestDependencyKey: DependencyKey {
+    static let liveValue: String = "live"
+}
+
+private struct NumberDependencyKey: DependencyKey {
+    static let liveValue: Int = 42
+}
+
+private struct BoolDependencyKey: DependencyKey {
     static let liveValue: Bool = false
 }
 
-struct UserConfig: Sendable, Equatable {
-    var name: String
-    var level: Int
-}
-
-enum UserConfigKey: DependencyKey {
-    static let liveValue: UserConfig = .init(name: "live", level: 0)
-}
-
 extension DependencyValues {
-    var featureEnabled: Bool {
-        get { self[FeatureFlagKey.self] }
-        set { self[FeatureFlagKey.self] = newValue }
+    fileprivate var testDependency: String {
+        get { self[TestDependencyKey.self] }
+        set { self[TestDependencyKey.self] = newValue }
     }
-    var userConfig: UserConfig {
-        get {self[UserConfigKey.self] }
-        set { self[UserConfigKey.self] = newValue}
+    
+    fileprivate var numberDependency: Int {
+        get { self[NumberDependencyKey.self] }
+        set { self[NumberDependencyKey.self] = newValue }
+    }
+    
+    fileprivate var boolDependency: Bool {
+        get { self[BoolDependencyKey.self] }
+        set { self[BoolDependencyKey.self] = newValue }
     }
 }
 
-struct FeatureConsumer {
-    @Dependency(\.featureEnabled) var enabled: Bool
-    func isOn() -> Bool { enabled }
+// MARK: - Test Helpers
+
+private struct TestService {
+    @Dependency(\.testDependency) var testValue: String
+    @Dependency(\.numberDependency) var numberValue: Int
+    @Dependency(\.boolDependency) var boolValue: Bool
 }
 
-struct ConfigConsumer {
-    @Dependency(\.userConfig) var config: UserConfig
-    func current() -> UserConfig { config }
-}
-
-// MARK: - テスト
+// MARK: - Tests
 
 @Suite
 struct DependencyValuesTests {
     
+    // MARK: - デフォルト値のテスト
+    
     @Test
-    func FeatureConsumerが_依存未設定の時_liveValueを返す() {
-        // given: 依存未設定
-        let consumer = FeatureConsumer()
-        // when: 参照
-        let v = consumer.isOn()
-        // then: liveValue(false)
-        #expect(v == false)
+    func カスタム値が設定されていない場合_依存性を取得した時_liveValueの文字列が返される() {
+        // Given: デフォルト状態のDependencyValues
+        let service = TestService()
+        
+        // When: 依存性の値を取得
+        let result = service.testValue
+        
+        // Then: liveValueである"live"が返される
+        #expect(result == "live")
     }
-
+    
     @Test
-    func FeatureConsumerが_同期スコープ内の時_上書き値trueを返しスコープ外はfalseを返す() {
-        // given: 外側はfalse
-        #expect(FeatureConsumer().isOn() == false)
-
-        // when: 同期スコープでtrueに上書き
-        let inside = DependencyValues.withDependency {
-            $0.featureEnabled = true
+    func カスタム値が設定されていない場合_数値型の依存性を取得した時_liveValueの42が返される() {
+        // Given: デフォルト状態のDependencyValues
+        let service = TestService()
+        
+        // When: 数値型の依存性を取得
+        let result = service.numberValue
+        
+        // Then: liveValueである42が返される
+        #expect(result == 42)
+    }
+    
+    // MARK: - withDependency同期版のテスト
+    
+    @Test
+    func withDependencyで値を上書きした場合_スコープ内で依存性を取得した時_上書きした文字列が返される() {
+        // Given: "test"という値で依存性を上書き
+        
+        // When: withDependencyのスコープ内で依存性を取得
+        let result = DependencyValues.withDependency {
+            $0.testDependency = "test"
         } operation: {
-            FeatureConsumer().isOn()
+            let service = TestService()
+            return service.testValue
         }
-
-        // then: 内=true 外=false
-        #expect(inside == true)
-        #expect(FeatureConsumer().isOn() == false)
+        
+        // Then: 上書きした"test"が返される
+        #expect(result == "test")
     }
-
+    
     @Test
-    func 依存スコープが_ネストされた時_内側の値が優先される() {
-        // given+when: 外= true → 内= false → 外に戻る
-        let tuple = DependencyValues.withDependency {
-            $0.featureEnabled = true
+    func withDependencyで値を上書きした場合_スコープ外で依存性を取得した時_liveValueの文字列が返される() {
+        // Given: withDependencyで一時的に値を上書き
+        _ = DependencyValues.withDependency {
+            $0.testDependency = "temporary"
         } operation: {
-            let outer = FeatureConsumer().isOn()
-            let inner = DependencyValues.withDependency({ $0[FeatureFlagKey.self] = false }) {
-                FeatureConsumer().isOn()
+            let service = TestService()
+            return service.testValue
+        }
+        
+        // When: スコープ外で依存性を取得
+        let service = TestService()
+        let result = service.testValue
+        
+        // Then: 元のliveValueである"live"が返される
+        #expect(result == "live")
+    }
+    
+    @Test
+    func withDependencyをネストした場合_内側のスコープで依存性を取得した時_最も内側で設定した値が返される() {
+        // Given: withDependencyを2重にネスト
+        
+        // When: 内側と外側で異なる値を設定し、内側で依存性を取得
+        let result = DependencyValues.withDependency {
+            $0.testDependency = "outer"
+        } operation: {
+            return DependencyValues.withDependency {
+                $0.testDependency = "inner"
+            } operation: {
+                let service = TestService()
+                return service.testValue
             }
-            let outerAgain = FeatureConsumer().isOn()
-            return (outer, inner, outerAgain)
         }
-
-        // then
-        #expect(tuple.0 == true)
-        #expect(tuple.1 == false)
-        #expect(tuple.2 == true)
-        #expect(FeatureConsumer().isOn() == false)
+        
+        // Then: 最も内側の"inner"が返される
+        #expect(result == "inner")
     }
-
+    
     @Test
-    func 子Taskが_非同期スコープ内の時_上書き値を参照する() async {
-        // given: 外側はfalse
-        #expect(FeatureConsumer().isOn() == false)
-
-        // when: 非同期スコープでtrueに上書きし子Taskで参照
-        let (direct, child) = await DependencyValues.withDependency {
-            $0.featureEnabled = true
+    func withDependencyをネストした場合_外側のスコープで依存性を取得した時_外側で設定した値が返される() {
+        // Given: withDependencyを2重にネスト
+        
+        // When: 内側のスコープを抜けた後、外側のスコープで依存性を取得
+        let result = DependencyValues.withDependency {
+            $0.testDependency = "outer"
         } operation: {
-            let d = FeatureConsumer().isOn()
-            let c = await Task { FeatureConsumer().isOn() }.value
-            return (d, c)
+            _ = DependencyValues.withDependency {
+                $0.testDependency = "inner"
+            } operation: {
+                let service = TestService()
+                return service.testValue
+            }
+            let service = TestService()
+            return service.testValue
         }
-
-        // then: スコープ内と子Taskの両方でtrue
-        #expect(direct == true)
-        #expect(child == true)
-        #expect(FeatureConsumer().isOn() == false)
+        
+        // Then: 外側で設定した"outer"が返される
+        #expect(result == "outer")
     }
-
+    
+    // MARK: - 複数の依存性のテスト
+    
     @Test
-    func 別キーが_上書きされた時_他のキーに影響しない() {
-        // given: 両キーlive
-        #expect(FeatureConsumer().isOn() == false)
-        #expect(ConfigConsumer().current() == .init(name: "live", level: 0))
-
-        // when: UserConfigのみ上書き
-        let (cfgIn, flagIn) = DependencyValues.withDependency {
-            $0.userConfig = .init(name: "custom", level: 2)
+    func 複数の依存性を設定した場合_それぞれの依存性を取得した時_設定した各値が返される() {
+        // Given: 3つの異なる依存性に値を設定
+        
+        // When: withDependencyで複数の依存性を設定し、各値を取得
+        let (stringResult, numberResult, boolResult) = DependencyValues.withDependency {
+            $0.testDependency = "custom"
+            $0.numberDependency = 100
+            $0.boolDependency = true
         } operation: {
-            (ConfigConsumer().current(), FeatureConsumer().isOn())
+            let service = TestService()
+            return (service.testValue, service.numberValue, service.boolValue)
         }
-
-        // then: UserConfigだけ変化/FeatureFlagは不変
-        #expect(cfgIn == .init(name: "custom", level: 2))
-        #expect(flagIn == false)
-
-        // スコープ外は元に戻る
-        #expect(ConfigConsumer().current() == .init(name: "live", level: 0))
-        #expect(FeatureConsumer().isOn() == false)
+        
+        // Then: それぞれ設定した値が返される
+        #expect(stringResult == "custom")
+        #expect(numberResult == 100)
+        #expect(boolResult == true)
     }
-
+    
     @Test
-    func 同一タスクが_awaitをまたぐ時_上書き値を維持する() async {
-        // given+when: 非同期スコープでtrueに上書きしawait境界を挟む
-        let kept = await DependencyValues.withDependency {
-            $0.featureEnabled = true
+    func 一部の依存性のみ上書きした場合_上書きしていない依存性を取得した時_liveValueが返される() {
+        // Given: testDependencyのみ上書き
+        
+        // When: 上書きした依存性と上書きしていない依存性を取得
+        let (customResult, defaultResult) = DependencyValues.withDependency {
+            $0.testDependency = "custom"
         } operation: {
-            _ = await Task { () }.value  // 微小await
-            return FeatureConsumer().isOn()
+            let service = TestService()
+            return (service.testValue, service.numberValue)
         }
-
-        // then: 同一タスク内ではtrueを維持、外ではfalse
-        #expect(kept == true)
-        #expect(FeatureConsumer().isOn() == false)
+        
+        // Then: 上書きした値は"custom"、上書きしていない値は42が返される
+        #expect(customResult == "custom")
+        #expect(defaultResult == 42)
+    }
+    
+    // MARK: - withDependency非同期版のテスト
+    
+    @Test
+    func 非同期withDependencyで値を上書きした場合_スコープ内で依存性を取得した時_上書きした文字列が返される() async {
+        // Given: "async_test"という値で依存性を上書き
+        
+        // When: 非同期withDependencyのスコープ内で依存性を取得
+        let result = await DependencyValues.withDependency {
+            $0.testDependency = "async_test"
+        } operation: {
+            try? await Task.sleep(nanoseconds: 100_000)
+            let service = TestService()
+            return service.testValue
+        }
+        
+        // Then: 上書きした"async_test"が返される
+        #expect(result == "async_test")
+    }
+    
+    @Test
+    func 非同期withDependencyで値を上書きした場合_非同期処理後も依存性を取得した時_上書きした値が返される() async {
+        // Given: "async_persistent"という値で依存性を上書き
+        // When: 非同期処理を挟んでから依存性を取得
+        let result = await DependencyValues.withDependency {
+            $0.testDependency = "async_persistent"
+        } operation: {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            let service = TestService()
+            return service.testValue
+        }
+        
+        // Then: 非同期処理後も"async_persistent"が返される
+        #expect(result == "async_persistent")
+    }
+    
+    @Test
+    func 非同期withDependencyで値を上書きした場合_スコープ外で依存性を取得した時_liveValueが返される() async {
+        // Given: withDependencyで一時的に値を上書き
+        _ = await DependencyValues.withDependency {
+            $0.testDependency = "temporary_async"
+        } operation: {
+            try? await Task.sleep(nanoseconds: 100_000)
+            let service = TestService()
+            return service.testValue
+        }
+        
+        // When: スコープ外で依存性を取得
+        let service = TestService()
+        let result = service.testValue
+        
+        // Then: 元のliveValueである"live"が返される
+        #expect(result == "live")
+    }
+    
+    @Test
+    func 非同期withDependencyをネストした場合_内側のスコープで依存性を取得した時_最も内側で設定した値が返される() async {
+        // Given: 非同期withDependencyを2重にネスト
+        
+        // When: 内側と外側で異なる値を設定し、内側で依存性を取得
+        let result = await DependencyValues.withDependency {
+            $0.testDependency = "async_outer"
+        } operation: {
+            try? await Task.sleep(nanoseconds: 100_000)
+            return await DependencyValues.withDependency {
+                $0.testDependency = "async_inner"
+            } operation: {
+                try? await Task.sleep(nanoseconds: 100_000)
+                let service = TestService()
+                return service.testValue
+            }
+        }
+        
+        // Then: 最も内側の"async_inner"が返される
+        #expect(result == "async_inner")
+    }
+    
+    @Test
+    func 非同期withDependencyをネストした場合_外側のスコープで依存性を取得した時_外側で設定した値が返される() async {
+        // Given: 非同期withDependencyを2重にネスト
+        
+        // When: 内側のスコープを抜けた後、外側のスコープで依存性を取得
+        let result = await DependencyValues.withDependency {
+            $0.testDependency = "async_outer"
+        } operation: {
+            try? await Task.sleep(nanoseconds: 100_000)
+            _ = await DependencyValues.withDependency {
+                $0.testDependency = "async_inner"
+            } operation: {
+                try? await Task.sleep(nanoseconds: 100_000)
+                let service = TestService()
+                return service.testValue
+            }
+            let service = TestService()
+            return service.testValue
+        }
+        
+        // Then: 外側で設定した"async_outer"が返される
+        #expect(result == "async_outer")
+    }
+    
+    @Test
+    func 非同期withDependencyをネストし異なる依存性を設定した場合_内側で両方の依存性を取得した時_それぞれ設定した値が返される() async {
+        // Given: 外側でtestDependency、内側でnumberDependencyを設定
+        
+        // When: ネストしたスコープで両方の依存性を取得
+        let result = await DependencyValues.withDependency {
+            $0.testDependency = "async_outer_value"
+        } operation: {
+            try? await Task.sleep(nanoseconds: 100_000)
+            return await DependencyValues.withDependency {
+                $0.numberDependency = 777
+            } operation: {
+                try? await Task.sleep(nanoseconds: 100_000)
+                let service = TestService()
+                return (service.testValue, service.numberValue)
+            }
+        }
+        
+        // Then: 外側で設定した"async_outer_value"と内側で設定した777が返される
+        #expect(result.0 == "async_outer_value")
+        #expect(result.1 == 777)
+    }
+    
+    // MARK: - @Dependencyプロパティラッパーのテスト
+    
+    @Test
+    func Dependencyプロパティラッパーを使用した場合_デフォルト状態で値を取得した時_liveValueが返される() {
+        // Given: Dependencyプロパティラッパーを持つ構造体
+        let service = TestService()
+        
+        // When: デフォルト状態で値を取得
+        // Then: 各liveValueが返される
+        #expect(service.testValue == "live")
+        #expect(service.numberValue == 42)
+    }
+    
+    @Test
+    func Dependencyプロパティラッパーを使用した場合_withDependencyスコープ内で値を取得した時_上書きした値が返される() {
+        // Given: Dependencyプロパティラッパーを持つ構造体
+        
+        // When: withDependencyで値を上書きした状態でインスタンスを作成
+        let result = DependencyValues.withDependency {
+            $0.testDependency = "injected"
+        } operation: {
+            let service = TestService()
+            return service.testValue
+        }
+        
+        // Then: 上書きした"injected"が返される
+        #expect(result == "injected")
+    }
+    
+    @Test
+    func Dependencyプロパティラッパーを複数持つ構造体で_一部の依存性のみ上書きした場合_上書きした依存性は設定値を返し上書きしていない依存性はliveValueを返す() {
+        // Given: 複数のDependencyプロパティラッパーを持つ構造体
+        
+        // When: testDependencyのみ上書き
+        let result = DependencyValues.withDependency {
+            $0.testDependency = "only_string_changed"
+        } operation: {
+            let service = TestService()
+            return (service.testValue, service.numberValue, service.boolValue)
+        }
+        
+        // Then: 上書きした値は"only_string_changed"、上書きしていない値は42とfalseが返される
+        #expect(result.0 == "only_string_changed")
+        #expect(result.1 == 42)
+        #expect(result.2 == false)
+    }
+    
+    // MARK: - エッジケースのテスト
+    
+    @Test
+    func withDependencyをネストし異なる依存性を設定した場合_内側で両方の依存性を取得した時_それぞれ設定した値が返される() {
+        // Given: 外側でtestDependency、内側でnumberDependencyを設定
+        
+        // When: ネストしたスコープで両方の依存性を取得
+        let result = DependencyValues.withDependency {
+            $0.testDependency = "outer_value"
+        } operation: {
+            DependencyValues.withDependency {
+                $0.numberDependency = 999
+            } operation: {
+                let service = TestService()
+                return (service.testValue, service.numberValue)
+            }
+        }
+        
+        // Then: 外側で設定した"outer_value"と内側で設定した999が返される
+        #expect(result.0 == "outer_value")
+        #expect(result.1 == 999)
     }
 }

--- a/SnapSearchTests/Mock/Network/MockAPIRequestProvider.swift
+++ b/SnapSearchTests/Mock/Network/MockAPIRequestProvider.swift
@@ -1,0 +1,36 @@
+//
+//  MockAPIRequestProvider.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/12
+//  
+
+@testable import SnapSearch
+
+final class MockAPIRequestProvider: APIRequestProviding, @unchecked Sendable {
+    /// fetchメソッドの戻り値を設定するためのプロパティ
+    var fetchResult: Result<Any, Error>?
+    /// fetchメソッドが呼ばれた回数をカウント
+    var fetchCallCount = 0
+    /// 最後に呼ばれたfetchメソッドのエンドポイントを保存
+    var lastEndpoint: APIEndpoint?
+    
+    func fetch<T: Decodable & Sendable>(_ endpoint: APIEndpoint) async throws -> T {
+        fetchCallCount += 1
+        lastEndpoint = endpoint
+        
+        guard let result = fetchResult else {
+            throw APIError.unknown
+        }
+        
+        switch result {
+        case .success(let value):
+            guard let typedValue = value as? T else {
+                throw APIError.decodingError("型が一致しません")
+            }
+            return typedValue
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/SnapSearchTests/PexelsAPIClientTests.swift
+++ b/SnapSearchTests/PexelsAPIClientTests.swift
@@ -1,0 +1,200 @@
+//
+//  PexelsAPIClientTests.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/12
+//  
+
+@testable import SnapSearch
+import Testing
+
+// MARK: - APIRequestClientInitTests
+
+@Suite
+struct APIRequestClientInitTests {
+    
+    @Test
+    func APIRequestClientが_APIキーとbaseURLを渡して生成する時_指定した値でconfigurationが設定される() {
+        // Given: APIキー"test-api-key"とbaseURL"https://api.example.com"を準備
+        let apiKey = "test-api-key"
+        let baseURL = "https://api.example.com"
+        
+        // When: createメソッドでクライアントを生成した時
+        let client = APIRequestClient.create(apiKey: apiKey, baseURL: baseURL)
+        
+        // Then: configurationに指定したAPIキーとbaseURLとタイムアウト30秒が設定される
+        #expect(client.configuration.apiKey == apiKey)
+        #expect(client.configuration.baseURL == baseURL)
+        #expect(client.configuration.timeout == 30)
+    }
+}
+
+// MARK: - PexelsAPIClientSearchTests
+
+@Suite("PexelsAPIClient searchPhotosテスト")
+struct PexelsAPIClientSearchTests {
+    
+    @Test("searchPhotosが_有効なクエリを渡した時_APIRequestProviderのfetchが1回呼ばれる")
+    func searchPhotosが_有効なクエリを渡した時_APIRequestProviderのfetchが1回呼ばれる() async throws {
+        // Given: モックプロバイダーと成功レスポンスを準備
+        let mockProvider = MockAPIRequestProvider()
+        let mockResponse = SearchResponse(totalResults: 0, page: 1, perPage: 10, photos: [], nextPage: nil)
+        mockProvider.fetchResult = .success(mockResponse)
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: query="ocean"でsearchPhotosを呼び出した時
+        _ = try await client.searchPhotos(query: "ocean", page: 1, perPage: 10)
+        
+        // Then: モックプロバイダーのfetchメソッドが1回呼ばれる
+        #expect(mockProvider.fetchCallCount == 1)
+    }
+    
+    @Test("searchPhotosが_空文字列のクエリを渡した時_invalidURLエラーがスローされる")
+    func searchPhotosが_空文字列のクエリを渡した時_invalidURLエラーがスローされる() async {
+        // Given: モックプロバイダーと空文字列""を準備
+        let mockProvider = MockAPIRequestProvider()
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: 空文字列でsearchPhotosを呼び出した時
+        // Then: APIError.invalidURLがスローされる
+        await #expect(throws: APIError.invalidURL) {
+            try await client.searchPhotos(query: "", page: 1, perPage: 10)
+        }
+    }
+    
+    @Test("searchPhotosが_空白のみのクエリを渡した時_invalidURLエラーがスローされる")
+    func searchPhotosが_空白のみのクエリを渡した時_invalidURLエラーがスローされる() async {
+        // Given: モックプロバイダーと空白のみの"   "を準備
+        let mockProvider = MockAPIRequestProvider()
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: 空白のみのクエリでsearchPhotosを呼び出した時
+        // Then: APIError.invalidURLがスローされる
+        await #expect(throws: APIError.invalidURL) {
+            try await client.searchPhotos(query: "   ", page: 1, perPage: 10)
+        }
+    }
+    
+    @Test("searchPhotosが_page2とperPage20を指定した時_searchエンドポイントに同じ値が渡される")
+    func searchPhotosが_page2とperPage20を指定した時_searchエンドポイントに同じ値が渡される() async throws {
+        // Given: モックプロバイダーとpage=2、perPage=20を準備
+        let mockProvider = MockAPIRequestProvider()
+        let mockResponse = SearchResponse(totalResults: 0, page: 2, perPage: 20, photos: [], nextPage: nil)
+        mockProvider.fetchResult = .success(mockResponse)
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: query="forest"、page=2、perPage=20でsearchPhotosを呼び出した時
+        _ = try await client.searchPhotos(query: "forest", page: 2, perPage: 20)
+        
+        // Then: エンドポイントにquery="forest"、page=2、perPage=20が渡される
+        guard case .search(let query, let page, let perPage) = mockProvider.lastEndpoint else {
+            Issue.record("エンドポイントがsearchではありません")
+            return
+        }
+        #expect(query == "forest")
+        #expect(page == 2)
+        #expect(perPage == 20)
+    }
+}
+
+// MARK: - PexelsAPIClientCuratedTests
+
+@Suite
+struct PexelsAPIClientCuratedTests {
+    
+    @Test("getCuratedPhotosが_page1とperPage15を指定した時_curatedエンドポイントに同じ値が渡される")
+    func getCuratedPhotosが_page1とperPage15を指定した時_curatedエンドポイントに同じ値が渡される() async throws {
+        // Given: モックプロバイダーとpage=1、perPage=15を準備
+        let mockProvider = MockAPIRequestProvider()
+        let mockResponse = SearchResponse(totalResults: 0, page: 1, perPage: 15, photos: [], nextPage: nil)
+        mockProvider.fetchResult = .success(mockResponse)
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: page=1、perPage=15でgetCuratedPhotosを呼び出した時
+        _ = try await client.getCuratedPhotos(page: 1, perPage: 15)
+        
+        // Then: エンドポイントにpage=1、perPage=15が渡される
+        guard case .curated(let page, let perPage) = mockProvider.lastEndpoint else {
+            Issue.record("エンドポイントがcuratedではありません")
+            return
+        }
+        #expect(page == 1)
+        #expect(perPage == 15)
+    }
+    
+    @Test("getCuratedPhotosが_呼び出された時_APIRequestProviderのfetchが1回呼ばれる")
+    func getCuratedPhotosが_呼び出された時_APIRequestProviderのfetchが1回呼ばれる() async throws {
+        // Given: モックプロバイダーと成功レスポンスを準備
+        let mockProvider = MockAPIRequestProvider()
+        let mockResponse = SearchResponse(totalResults: 0, page: 1, perPage: 10, photos: [], nextPage: nil)
+        mockProvider.fetchResult = .success(mockResponse)
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: getCuratedPhotosを呼び出した時
+        _ = try await client.getCuratedPhotos(page: 1, perPage: 10)
+        
+        // Then: モックプロバイダーのfetchメソッドが1回呼ばれる
+        #expect(mockProvider.fetchCallCount == 1)
+    }
+}
+
+// MARK: - PexelsAPIClientPhotoTests
+
+@Suite
+struct PexelsAPIClientPhotoTests {
+    
+    @Test("getPhotoが_ID123を指定した時_photoエンドポイントにID123が渡される")
+    func getPhotoが_ID123を指定した時_photoエンドポイントにID123が渡される() async throws {
+        // Given: モックプロバイダーとID=123のPhotoレスポンスを準備
+        let mockProvider = MockAPIRequestProvider()
+        let mockPhotoSource = PhotoSource(
+            original: "https://example.com/original.jpg",
+            large2x: "https://example.com/large2x.jpg",
+            large: "https://example.com/large.jpg",
+            medium: "https://example.com/medium.jpg",
+            small: "https://example.com/small.jpg",
+            portrait: "https://example.com/portrait.jpg",
+            landscape: "https://example.com/landscape.jpg",
+            tiny: "https://example.com/tiny.jpg"
+        )
+        let mockPhoto = Photo(
+            id: 123,
+            width: 800,
+            height: 600,
+            url: "https://example.com",
+            photographer: "Test Photographer",
+            photographerURL: "https://example.com/photographer",
+            photographerID: 1,
+            avgColor: "#FFFFFF",
+            src: mockPhotoSource,
+            liked: false,
+            alt: "Test photo"
+        )
+        mockProvider.fetchResult = .success(mockPhoto)
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: ID=123でgetPhotoを呼び出した時
+        _ = try await client.getPhoto(id: 123)
+        
+        // Then: エンドポイントにID=123が渡される
+        guard case .photo(let id) = mockProvider.lastEndpoint else {
+            Issue.record("エンドポイントがphotoではありません")
+            return
+        }
+        #expect(id == 123)
+    }
+    
+    @Test("getPhotoが_APIがエラーを返す時_エラーがそのままスローされる")
+    func getPhotoが_APIがエラーを返す時_エラーがそのままスローされる() async {
+        // Given: モックプロバイダーにunauthorizedエラーを設定
+        let mockProvider = MockAPIRequestProvider()
+        mockProvider.fetchResult = .failure(APIError.unauthorized)
+        let client = PexelsAPIClient(apiRequestProvider: mockProvider)
+        
+        // When: getPhotoを呼び出した時
+        // Then: APIError.unauthorizedがスローされる
+        await #expect(throws: APIError.unauthorized) {
+            try await client.getPhoto(id: 999)
+        }
+    }
+}


### PR DESCRIPTION
## 概要
https://github.com/FujimoriGit/SnapSearch/pull/7 で追加したAPIリクエスト周りの動作を担保するため、UnitTestを作成。

## 変更内容
- APIリクエスト周りのテストを行うためのモックを作成
- APIリクエスト周りの各要素のUnitTest作成
- DependencyValuesのUnitTestを修正

## 動作確認
<!-- 動作確認した内容をチェックリストで記述 -->
- [x] ビルドができること


## スクリーンショット
<!-- UI変更がある場合は貼ってください -->

## その他
<!-- レビューしてほしい観点やTODOなど -->
