### PR TITLE
NavigationValuesを作成

### DIFF
--- a/SnapSearch/Core/Navigation/NavigationValues.swift
+++ b/SnapSearch/Core/Navigation/NavigationValues.swift
@@ -1,0 +1,117 @@
+//
+//  NavigationRouter.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/13
+//  
+
+import SwiftUI
+
+// MARK: - NavigationKey
+
+protocol NavigationKey {
+    associatedtype Value: Sendable
+    static var liveValue: Value { get }
+}
+
+// MARK: - NavigationValues
+
+struct NavigationValues: Sendable {
+
+    @TaskLocal fileprivate static var current = Self()
+    private var storage: [ObjectIdentifier: Sendable] = [:]
+
+    // swiftlint:disable:next unneeded_synthesized_initializer
+    private init() {}
+
+    subscript<K>(key: K.Type) -> K.Value where K: NavigationKey {
+        
+        get {
+            
+            guard let base = storage[ObjectIdentifier(key)] as? K.Value else {
+                
+                return key.liveValue
+            }
+            return base
+        }
+        
+        set {
+            
+            storage[ObjectIdentifier(key)] = newValue
+        }
+    }
+}
+
+extension NavigationValues {
+    
+    static func scoped<K: NavigationKey, R>(
+        _ key: K.Type,
+        to value: K.Value,
+        operation: () -> R
+    ) -> R {
+        var snap = NavigationValues.current
+        snap[key] = value
+        return NavigationValues.$current.withValue(snap) { operation() }
+    }
+    
+    static func scoped<K: NavigationKey, R>(
+        _ key: K.Type,
+        to value: K.Value,
+        operation: () async -> R
+    ) async -> R {
+        var snap = NavigationValues.current
+        snap[key] = value
+        return await NavigationValues.$current.withValue(snap) { await operation() }
+    }
+    
+    /// 指定KeyPathに対応する値を差し替え、指定したViewのサブツリーにだけ適用します
+    static func scoped<Value, Content: View>(
+        _ keyPath: WritableKeyPath<NavigationValues, Value>,
+        to value: Value,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        var snap = NavigationValues.current
+        snap[keyPath: keyPath] = value
+        return NavigationValues.$current.withValue(snap) { content() }
+    }
+}
+
+// MARK: - NavigationRoot
+
+/// 指定Keyに Routerを注入し、このサブツリーにだけ有効化するView
+struct NavigationRoot<R: Hashable & Sendable, Content: View>: View {
+    
+    private let keyPath: WritableKeyPath<NavigationValues, Router<R>>
+    @State private var router: Router<R>
+    private let content: () -> Content
+
+    init(_ keyPath: WritableKeyPath<NavigationValues, Router<R>>,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.keyPath = keyPath
+        router = NavigationValues.current[keyPath: keyPath]
+        self.content = content
+    }
+
+    var body: some View {
+        NavigationValues.scoped(keyPath, to: router) {
+            NavigationStack(path: $router.path) {
+                content()
+            }
+        }
+    }
+}
+
+// MARK: - propertyWrapper
+
+@propertyWrapper
+struct Navigation<Value> {
+    
+    private let keyPath: KeyPath<NavigationValues, Value> & Sendable
+
+    init(_ keyPath: KeyPath<NavigationValues, Value> & Sendable) {
+        
+        self.keyPath = keyPath
+    }
+
+    var wrappedValue: Value { NavigationValues.current[keyPath: keyPath] }
+}

--- a/SnapSearch/Views/Router/NavigationRoot.swift
+++ b/SnapSearch/Views/Router/NavigationRoot.swift
@@ -1,0 +1,9 @@
+//
+//  NavigationRoot.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/13
+//  
+
+import SwiftUI
+

--- a/SnapSearch/Views/Router/Route/SearchRoute.swift
+++ b/SnapSearch/Views/Router/Route/SearchRoute.swift
@@ -1,0 +1,25 @@
+//
+//  SearchRoute.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/13
+//  
+
+// MARK: - SearchRoute
+
+enum SearchRoute: Hashable, Sendable, CaseIterable {
+    case photoDetail
+}
+
+// MARK: - NavigationValues injection
+
+private enum SearchRouterKey: NavigationKey {
+    static let liveValue: Router<SearchRoute> = Router()
+}
+
+extension NavigationValues {
+    var search: Router<SearchRoute> {
+        get { self[SearchRouterKey.self] }
+        set { self[SearchRouterKey.self] = newValue }
+    }
+}

--- a/SnapSearch/Views/Router/Router.swift
+++ b/SnapSearch/Views/Router/Router.swift
@@ -1,0 +1,56 @@
+//
+//  Router.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/13
+//  
+
+import Foundation
+
+// MARK: - Navigator
+
+/// UIスタックの実体
+@MainActor
+@Observable
+final class Navigator {
+    /// 表示中ルートの履歴
+    var path: [AnyHashable] = []
+    
+    nonisolated init() {}
+
+    func push(_ route: AnyHashable) { path.append(route) }
+    func pop() {
+        guard !path.isEmpty else { return }
+        path.removeLast()
+    }
+    func popToRoot() { path.removeAll(keepingCapacity: false) }
+}
+
+// MARK: - Router
+
+/// ViewModelからUI遷移を発火する構造体
+@MainActor
+@Observable
+final class Router<R: Hashable & Sendable>: Sendable {
+    
+    var path: [R] = [] {
+        
+        didSet{
+            logger.debug(.view, "\(oldValue) -> \(self.path)")
+        }
+    }
+    nonisolated init() {}
+}
+
+extension Router {
+    
+    func push(_ route: R) { path.append(route) }
+    
+    func pop() {
+        
+        guard !path.isEmpty else { return }
+        path.removeLast()
+    }
+    
+    func popToRoot() { path.removeAll(keepingCapacity: false) }
+}


### PR DESCRIPTION
## 概要
Viewから副作用（遷移命令）を排除し、DIを通じて明示的にRouterを渡し、ViewModel側で遷移を実行出来る仕組みを追加。

## 変更内容
NavigationValuesを作成

## 動作確認
<!-- 動作確認した内容をチェックリストで記述 -->
- [x] ビルドできること
- [x] 遷移できること（デバッグコードで確認）


## スクリーンショット
<!-- UI変更がある場合は貼ってください -->

## その他
<!-- レビューしてほしい観点やTODOなど -->
