### PR TITLE
写真表示画面実装

### DIFF
--- a/SnapSearch/Views/PhotoDetail/PhotoDetailView.swift
+++ b/SnapSearch/Views/PhotoDetail/PhotoDetailView.swift
@@ -1,0 +1,168 @@
+//
+//  PhotoDetailView.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/14
+//  
+
+import SwiftUI
+
+struct PhotoDetailView: View {
+    
+    @State private var viewModel: PhotoDetailViewModel
+    
+    init(photo: Photo) {
+        viewModel = PhotoDetailViewModel(photo: photo)
+    }
+    
+    private var toolbarVisibility: Visibility {
+        viewModel.state.isNavigationHidden ? .hidden : .visible
+    }
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Color.black.ignoresSafeArea()
+                
+                photoContent(viewModel.state, parentSize: geometry.size)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                VStack(spacing: 0) {
+                    Text(viewModel.state.photo.photographer)
+                        .font(.headline)
+                    
+                    if let alt = viewModel.state.photo.alt {
+                        Text(alt)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            
+            ToolbarItem(placement: .topBarTrailing) {
+                shareButton(photo: viewModel.state.photo)
+            }
+        }
+        .toolbar(toolbarVisibility, for: .navigationBar)
+        .task {
+            await viewModel.onAppear()
+        }
+    }
+}
+
+private extension PhotoDetailView {
+    
+    @ViewBuilder
+    func photoContent(_ state: PhotoDetailViewState, parentSize: CGSize) -> some View {
+        
+        if let imageData = state.imageData,
+           let uiImage = UIImage(data: imageData) {
+            
+            imageView(uiImage, state: state, parentSize: parentSize)
+        } else if state.isLoadingImage {
+            
+            VStack(spacing: 16) {
+                ProgressView()
+                Text("画像を読み込み中...")
+                    .foregroundStyle(.white.opacity(0.8))
+            }
+        } else if let error = state.imageLoadError {
+            
+            errorView(error)
+        }
+    }
+    
+    func imageView(_ uiImage: UIImage, state: PhotoDetailViewState, parentSize: CGSize) -> some View {
+        Image(uiImage: uiImage)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(maxWidth: parentSize.width)
+            .scaleEffect(state.scale)
+            .offset(state.offset)
+            .animation(.spring(), value: state.scale)
+            .animation(.spring(), value: state.offset)
+            .gesture(
+                MagnificationGesture()
+                    .onChanged { value in
+                        viewModel.onMagnificationGestureChanged(value)
+                    }
+                    .onEnded { _ in
+                        viewModel.onMagnificationGestureEnded()
+                    }
+                    .simultaneously(with: DragGesture()
+                        .onChanged { value in
+                            viewModel.onDragGestureChanged(value.translation)
+                        }
+                        .onEnded { _ in
+                            viewModel.onDragGestureEnded()
+                        }
+                    )
+            )
+            .onTapGesture(count: 1) {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    viewModel.onSingleTapped()
+                }
+            }
+            .onTapGesture(count: 2) {
+                withAnimation(.spring()) {
+                    viewModel.onDoubleTapped()
+                }
+            }
+    }
+    
+    func shareButton(photo: Photo) -> some View {
+        Menu {
+            Button {
+                viewModel.tappedMenuButton(photo.url)
+            } label: {
+                Label("Pexelsで開く", systemImage: "globe")
+            }
+            
+            Button {
+                viewModel.tappedMenuButton(photo.photographerURL)
+            } label: {
+                Label("フォトグラファーのページ", systemImage: "person.circle")
+            }
+            
+            if let imageData = viewModel.state.imageData,
+               let uiImage = UIImage(data: imageData) {
+                ShareLink(
+                    item: Image(uiImage: uiImage),
+                    preview: SharePreview(
+                        photo.alt ?? "Photo",
+                        image: Image(uiImage: uiImage)
+                    )
+                ) {
+                    Label("画像を共有", systemImage: "square.and.arrow.up")
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+    }
+    
+    func errorView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundStyle(.orange)
+            
+            Text("画像の読み込みに失敗しました")
+                .foregroundStyle(.white)
+            
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            
+            Button("再試行") {
+                viewModel.tappedRetryButton()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}

--- a/SnapSearch/Views/PhotoDetail/PhotoDetailView.swift
+++ b/SnapSearch/Views/PhotoDetail/PhotoDetailView.swift
@@ -27,19 +27,12 @@ struct PhotoDetailView: View {
                 photoContent(viewModel.state, parentSize: geometry.size)
             }
         }
-        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                VStack(spacing: 0) {
-                    Text(viewModel.state.photo.photographer)
-                        .font(.headline)
-                    
-                    if let alt = viewModel.state.photo.alt {
-                        Text(alt)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                Text(viewModel.state.photo.photographer)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
             
             ToolbarItem(placement: .topBarTrailing) {
@@ -47,6 +40,7 @@ struct PhotoDetailView: View {
             }
         }
         .toolbar(toolbarVisibility, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .task {
             await viewModel.onAppear()
         }

--- a/SnapSearch/Views/PhotoDetail/PhotoDetailViewModel.swift
+++ b/SnapSearch/Views/PhotoDetail/PhotoDetailViewModel.swift
@@ -1,0 +1,129 @@
+//
+//  PhotoDetailViewModel.swift
+//  SnapSearch
+//  
+//  Created by Daiki Fujimori on 2025/10/14
+//  
+
+import Foundation
+import UIKit
+
+// MARK: - PhotoDetailViewState
+
+struct PhotoDetailViewState: Equatable, Sendable {
+    let photo: Photo
+    var imageData: Data?
+    var isLoadingImage = false
+    var imageLoadError: String?
+    var isNavigationHidden = false
+    var scale: CGFloat = 1.0
+    var offset: CGSize = .zero
+}
+
+// MARK: - PhotoDetailViewModel
+
+@MainActor
+@Observable
+final class PhotoDetailViewModel {
+    
+    // MARK: - public property
+    
+    private(set) var state: PhotoDetailViewState
+    
+    // MARK: - private properties
+    
+    @ObservationIgnored
+    @Dependency(\.imageLoadingProvider) private var imageLoader
+    
+    private var lastScale: CGFloat = 1.0
+    private var lastOffset: CGSize = .zero
+    
+    // MARK: - initialize
+    
+    init(photo: Photo) {
+        self.state = PhotoDetailViewState(photo: photo)
+    }
+}
+
+// MARK: - public method
+
+extension PhotoDetailViewModel {
+    
+    func onAppear() async {
+        await loadFullImage()
+    }
+    
+    func onMagnificationGestureChanged(_ value: CGFloat) {
+        let delta = value / lastScale
+        lastScale = value
+        state.scale *= delta
+    }
+    
+    func onMagnificationGestureEnded() {
+        lastScale = 1.0
+        state.scale = min(max(state.scale, 1), 4)
+    }
+    
+    func onDragGestureChanged(_ translation: CGSize) {
+        state.offset = CGSize(
+            width: lastOffset.width + translation.width,
+            height: lastOffset.height + translation.height
+        )
+    }
+    
+    func onDragGestureEnded() {
+        lastOffset = state.offset
+        if state.scale <= 1 {
+            state.offset = .zero
+            lastOffset = .zero
+        }
+    }
+    
+    func onSingleTapped() {
+        state.isNavigationHidden.toggle()
+    }
+    
+    func onDoubleTapped() {
+        if state.scale > 1 {
+            state.scale = 1
+            state.offset = .zero
+            lastOffset = .zero
+        } else {
+            state.scale = 2
+        }
+    }
+    
+    func tappedRetryButton() {
+        Task {
+            await loadFullImage()
+        }
+    }
+    
+    func tappedMenuButton(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+
+// MARK: - private method
+
+private extension PhotoDetailViewModel {
+    
+    func loadFullImage() async {
+        guard state.imageData == nil else { return }
+        
+        state.isLoadingImage = true
+        state.imageLoadError = nil
+        
+        do {
+            let data = try await imageLoader.loadImage(
+                from: state.photo.src.large2x
+            )
+            state.imageData = data
+        } catch {
+            state.imageLoadError = error.localizedDescription
+        }
+        
+        state.isLoadingImage = false
+    }
+}

--- a/SnapSearch/Views/PhotoDetail/PhotoDetailViewModel.swift
+++ b/SnapSearch/Views/PhotoDetail/PhotoDetailViewModel.swift
@@ -15,7 +15,7 @@ struct PhotoDetailViewState: Equatable, Sendable {
     var imageData: Data?
     var isLoadingImage = false
     var imageLoadError: String?
-    var isNavigationHidden = false
+    var isNavigationHidden = true
     var scale: CGFloat = 1.0
     var offset: CGSize = .zero
 }

--- a/SnapSearch/Views/Router/Route/SearchRoute.swift
+++ b/SnapSearch/Views/Router/Route/SearchRoute.swift
@@ -7,8 +7,25 @@
 
 // MARK: - SearchRoute
 
-enum SearchRoute: Hashable, Sendable, CaseIterable {
-    case photoDetail
+enum SearchRoute: Sendable {
+    case photoDetail(Photo)
+}
+
+extension SearchRoute: Hashable {
+    
+    static func == (lhs: SearchRoute, rhs: SearchRoute) -> Bool {
+        switch (lhs, rhs) {
+        case (.photoDetail(let lhsPhoto), .photoDetail(let rhsPhoto)):
+            return lhsPhoto.id == rhsPhoto.id
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case .photoDetail(let photo):
+            hasher.combine(photo.id)
+        }
+    }
 }
 
 // MARK: - NavigationValues injection

--- a/SnapSearch/Views/Search/SearchView.swift
+++ b/SnapSearch/Views/Search/SearchView.swift
@@ -18,6 +18,14 @@ struct SearchView: View {
             searchContent(viewModel.state)
                 .navigationTitle("写真検索")
                 .navigationBarTitleDisplayMode(.large)
+                .navigationDestination(for: SearchRoute.self) {
+                    
+                    switch $0 {
+                        
+                    case .photoDetail(let photo):
+                        PhotoDetailView(photo: photo)
+                    }
+                }
         }
     }
 }
@@ -91,7 +99,7 @@ private extension SearchView {
         .background(Color(.systemBackground))
     }
     
-    private func photoGrid(_ state: SearchViewState) -> some View {
+    func photoGrid(_ state: SearchViewState) -> some View {
         ScrollView {
             LazyVGrid(
                 columns: [
@@ -100,10 +108,14 @@ private extension SearchView {
                 spacing: 2
             ) {
                 ForEach(state.photos) { photo in
-                    PhotoThumbnailView(photo: photo)
-                        .onAppear {
-                            viewModel.onAppearThumbnail(photo: photo)
-                        }
+                    Button {
+                        viewModel.tappedThumbnail(photo: photo)
+                    } label: {
+                        PhotoThumbnailView(photo: photo)
+                            .onAppear {
+                                viewModel.onAppearThumbnail(photo: photo)
+                            }
+                    }
                 }
                 
                 // ローディングインジケータ

--- a/SnapSearch/Views/Search/SearchViewModel.swift
+++ b/SnapSearch/Views/Search/SearchViewModel.swift
@@ -36,6 +36,9 @@ final class SearchViewModel {
     @ObservationIgnored
     @Dependency(\.imageLoadingProvider) private var imageLoader
     
+    @ObservationIgnored
+    @Navigation(\.search) private var router
+    
     private var currentPage = 1
     private var currentQuery = ""
     private var searchTask: Task<Void, Never>?
@@ -74,6 +77,11 @@ extension SearchViewModel {
         Task {
             await performSearch(resetResults: false)
         }
+    }
+    
+    func tappedThumbnail(photo: Photo) {
+        
+        router.push(.photoDetail(photo))
     }
     
     func enteredSearchText(_ text: String) {


### PR DESCRIPTION
## 概要
写真表示画面実装

## 変更内容
- 写真表示画面と拡大・縮小、共有機能を実装
- 写真検索画面からの遷移処理実装

## 動作確認
<!-- 動作確認した内容をチェックリストで記述 -->
- [x] 検索結果の写真をタップして詳細画面に遷移できること
- [x] 詳細画面の画像を拡大・縮小できること
- [x] 「Pexelsで開く」をタップしてブラウザにてURLが開くこと
- [x] 「フォトグラファーページを開く」をタップしてブラウザにてURLが開くこと
- [x] 「画像を共有」をタップしてOSの共有画面が表示されること

## スクリーンショット
<img src="https://github.com/user-attachments/assets/93f8a653-1450-400e-8416-1c26d46a82f7" width="250">
<img src="https://github.com/user-attachments/assets/59914741-7cd3-43df-ad72-a7bc4568b4ff" width="250">
<img src="https://github.com/user-attachments/assets/492eb717-375a-4f92-b142-60d803d84aad" width="250">

## その他
<!-- レビューしてほしい観点やTODOなど -->
